### PR TITLE
chore: add support for adding manually created secrets and sentry

### DIFF
--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.0-beta.2"
+appVersion: "v1.0.0-beta.3"

--- a/charts/runner/README.md
+++ b/charts/runner/README.md
@@ -2,24 +2,29 @@
 
 ### Runner configuration Parameters
 
-| Name                              | Description                                                    | Value   |
-| --------------------------------- | -------------------------------------------------------------- | ------- |
-| `config.apps`                     | Configuration values for the VCS apps to be used by the runner | `[]`    |
-| `config.deepsource.host`          | The host of the deepsource remote                              | `""`    |
-| `config.deepsource.publicKey`     | The public key to use for the deepsource remote                | `""`    |
-| `config.objectStorage.backend`    | The backend to use for the object storage (e.g gcs)            | `""`    |
-| `config.objectStorage.bucket`     | The bucket to use for the object storage                       | `""`    |
-| `config.objectStorage.credential` | The credentials value to use for the object storage            | `""`    |
-| `config.runner.id`                | The id of the runner                                           | `""`    |
-| `config.runner.host`              | The host of the runner to use                                  | `""`    |
-| `config.runner.clientId`          | The client id to use for the runner                            | `""`    |
-| `config.runner.clientSecret`      | The client secret to use for the runner                        | `""`    |
-| `config.runner.privateKey`        | The private key to use for the runner                          | `""`    |
-| `config.runner.webhookSecret`     | The webhook secret to use for the runner                       | `""`    |
-| `config.saml.enabled`             | Whether to enable SAML2.0 authentication                       | `false` |
-| `config.saml.certificate`         | The certificate to use for the runner as service provider      | `""`    |
-| `config.saml.key`                 | The private key to use for the runner as service provider      | `""`    |
-| `config.saml.metadataUrl`         | The metadata url to use for the identity provider              | `""`    |
+| Name                                | Description                                                                 | Value   |
+| ----------------------------------- | --------------------------------------------------------------------------- | ------- |
+| `config.createSecret`               | Whether to create a secret for the runner config                            | `true`  |
+| `config.secretName`                 | The name of the secret to use for the runner, if created externally         | `""`    |
+| `config.apps`                       | Configuration values for the VCS apps to be used by the runner              | `[]`    |
+| `config.deepsource.host`            | The host of the deepsource remote                                           | `""`    |
+| `config.deepsource.publicKey`       | The public key to use for the deepsource remote                             | `""`    |
+| `config.objectStorage.createSecret` | Whether to create a secret for the object storage                           | `true`  |
+| `config.objectStorage.secretName`   | The name of the secret to use for the object storage, if created externally | `""`    |
+| `config.objectStorage.provider`     | The provider to use for the object storage (e.g gcs, s3)                    | `""`    |
+| `config.objectStorage.bucket`       | The bucket to use for the object storage                                    | `""`    |
+| `config.objectStorage.credential`   | The credentials value to use for the object storage                         | `""`    |
+| `config.runner.id`                  | The id of the runner                                                        | `""`    |
+| `config.runner.host`                | The host of the runner to use                                               | `""`    |
+| `config.runner.clientId`            | The client id to use for the runner                                         | `""`    |
+| `config.runner.clientSecret`        | The client secret to use for the runner                                     | `""`    |
+| `config.runner.privateKey`          | The private key to use for the runner                                       | `""`    |
+| `config.runner.webhookSecret`       | The webhook secret to use for the runner                                    | `""`    |
+| `config.saml.enabled`               | Whether to enable SAML2.0 authentication                                    | `false` |
+| `config.saml.certificate`           | The certificate to use for the runner as service provider                   | `""`    |
+| `config.saml.key`                   | The private key to use for the runner as service provider                   | `""`    |
+| `config.saml.metadataUrl`           | The metadata url to use for the identity provider                           | `""`    |
+| `config.sentry.dsn`                 | The DSN to use for the sentry integration                                   | `""`    |
 
 ### Common Parameters
 
@@ -29,6 +34,8 @@
 | `image.repository`                              | deepsource runner image repository                                                                                               | `proxy.deepsource.com/images/deepsource-production/runner` |
 | `image.pullPolicy`                              | deepsource runner image pull policy                                                                                              | `Always`                                                   |
 | `image.tag`                                     | deepsource runner image tag                                                                                                      | `""`                                                       |
+| `imageRegistry.createSecret`                    | Whether to create a secret for the image registry                                                                                | `true`                                                     |
+| `imageRegistry.secretName`                      | The name of the secret to use for the image registry, if created externally                                                      | `""`                                                       |
 | `imageRegistry.registryUrl`                     | The registry url to use for the task images                                                                                      | `""`                                                       |
 | `imageRegistry.username`                        | The username to use for the image registry                                                                                       | `""`                                                       |
 | `imageRegistry.password`                        | The password to use for the image registry                                                                                       | `""`                                                       |

--- a/charts/runner/templates/artifact-secret.yaml
+++ b/charts/runner/templates/artifact-secret.yaml
@@ -1,8 +1,10 @@
+{{ if .Values.secrets.artifactsSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "artifacts-credentials"
+  name: {{ .Values.secrets.artifactsSecret.secretName }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   credentials: {{ .Values.config.objectStorage.credential | b64enc | indent 2 }}
+{{ end }}

--- a/charts/runner/templates/artifact-secret.yaml
+++ b/charts/runner/templates/artifact-secret.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.secrets.artifactsSecret.create }}
+{{ if .Values.config.objectStorage.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secrets.artifactsSecret.secretName }}
+  name: {{ include "runner.fullname" . }}-object-storage
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:

--- a/charts/runner/templates/deployment.yaml
+++ b/charts/runner/templates/deployment.yaml
@@ -46,9 +46,12 @@ spec:
               value: {{ .Release.Namespace }}
             - name: TASK_NODE_SELECTOR
               value: {{ .Values.nodeSelector | toYaml | toString | quote }}
-            - name: TASK_ANALYSIS_ARTIFACT_SECRET_NAME
-              value: {{ .Values.secrets.artifactsSecret.secretName }}
-
+            - name: TASK_ARTIFACT_SECRET_NAME
+            {{- if .Values.config.objectStorage.createSecret }}
+              value: {{ include "runner.fullname" . }}-object-storage
+            {{- else }}
+              value: {{ .Values.config.objectStorage.secretName }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -74,7 +77,11 @@ spec:
       volumes:
         - name: secret
           secret:
-            secretName: {{ .Values.secrets.runnerSecret.secretName }}
+            {{- if .Values.config.createSecret}}
+            secretName: {{ include "runner.fullname" . }}
+            {{- else }}
+            secretName: {{ .Values.config.secretName }}
+            {{- end }}
             items:
               - key: config
                 path: config.yaml

--- a/charts/runner/templates/deployment.yaml
+++ b/charts/runner/templates/deployment.yaml
@@ -21,7 +21,11 @@ spec:
         {{- include "runner.selectorLabels" . | nindent 8 }}
     spec:
       imagePullSecrets:
+        {{- if .Values.imageRegistry.createSecret }}
         - name: {{ include "runner.fullname" . }}-image-registry
+        {{- else }}
+        - name: {{ .Values.imageRegistry.secretName }}
+        {{- end }}
       serviceAccountName: {{ include "runner.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -39,7 +43,11 @@ spec:
             - name: RQLITE_PORT
               value: "4001"
             - name: TASK_IMAGE_PULL_SECRET_NAME
+              {{- if .Values.imageRegistry.createSecret }}
               value: {{ include "runner.fullname" . }}-image-registry
+              {{- else }}
+              value: {{ .Values.imageRegistry.secretName }}
+              {{- end }}
             - name: TASK_IMAGE_REGISTRY_URL
               value: {{ .Values.imageRegistry.registryUrl }}
             - name: TASK_NAMESPACE
@@ -47,11 +55,11 @@ spec:
             - name: TASK_NODE_SELECTOR
               value: {{ .Values.nodeSelector | toYaml | toString | quote }}
             - name: TASK_ARTIFACT_SECRET_NAME
-            {{- if .Values.config.objectStorage.createSecret }}
+              {{- if .Values.config.objectStorage.createSecret }}
               value: {{ include "runner.fullname" . }}-object-storage
-            {{- else }}
+              {{- else }}
               value: {{ .Values.config.objectStorage.secretName }}
-            {{- end }}
+              {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/runner/templates/deployment.yaml
+++ b/charts/runner/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
               value: {{ .Release.Namespace }}
             - name: TASK_NODE_SELECTOR
               value: {{ .Values.nodeSelector | toYaml | toString | quote }}
+            - name: TASK_ANALYSIS_ARTIFACT_SECRET_NAME
+              value: {{ .Values.secrets.artifactsSecret.secretName }}
+
           ports:
             - name: http
               containerPort: 8080

--- a/charts/runner/templates/deployment.yaml
+++ b/charts/runner/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
       volumes:
         - name: secret
           secret:
-            secretName: {{ include "runner.fullname" . }}
+            secretName: {{ .Values.secrets.runnerSecret.secretName }}
             items:
               - key: config
                 path: config.yaml

--- a/charts/runner/templates/image-pull-secret.yaml
+++ b/charts/runner/templates/image-pull-secret.yaml
@@ -10,7 +10,7 @@ stringData:
 {{- $auth := printf "%s:%s" .Values.imageRegistry.username .Values.imageRegistry.password | b64enc }}
     {
       "auths": {
-        "{{ .Values.imageRegistry.registryUrl }}": {
+        "proxy.deepsource.com": {
           "username": "{{ .Values.imageRegistry.username }}",
           "password": "{{ .Values.imageRegistry.password }}",
           "auth": "{{ $auth }}"

--- a/charts/runner/templates/image-pull-secret.yaml
+++ b/charts/runner/templates/image-pull-secret.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.secrets.imagePullSecret.create }}
+{{ if .Values.imageRegistry.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secrets.imagePullSecret.secretName }}
+  name: {{ include "runner.fullname" . }}-image-registry
   namespace: {{ .Release.Namespace }}
 type: kubernetes.io/dockerconfigjson
 stringData:

--- a/charts/runner/templates/image-pull-secret.yaml
+++ b/charts/runner/templates/image-pull-secret.yaml
@@ -1,7 +1,8 @@
+{{ if .Values.secrets.imagePullSecret.create }}
 apiVersion: v1
 kind: Secret
-metadata: 
-  name: {{ include "runner.fullname" . }}-image-registry
+metadata:
+  name: {{ .Values.secrets.imagePullSecret.secretName }}
   namespace: {{ .Release.Namespace }}
 type: kubernetes.io/dockerconfigjson
 stringData:
@@ -16,3 +17,4 @@ stringData:
         }
       }
     }
+{{ end }}

--- a/charts/runner/templates/secret.yaml
+++ b/charts/runner/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.secrets.runnerSecret.create }}
+{{ if .Values.config.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secrets.runnerSecret.secretName }}
+  name: {{ include "runner.fullname" . }}
   namespace: {{ .Release.Namespace }}
 type: Generic
 data:

--- a/charts/runner/templates/secret.yaml
+++ b/charts/runner/templates/secret.yaml
@@ -1,9 +1,11 @@
+{{ if .Values.secrets.runnerSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "runner.fullname" . }}
+  name: {{ .Values.secrets.runnerSecret.secretName }}
   namespace: {{ .Release.Namespace }}
 type: Generic
 data:
   config: |
 {{ .Values.config | toYaml | toString | b64enc | indent 4 }}
+{{ end }}

--- a/charts/runner/values.schema.json
+++ b/charts/runner/values.schema.json
@@ -62,13 +62,21 @@
                 "objectStorage": {
                     "type": "object",
                     "properties": {
-                        "backend": {
+                        "provider": {
                             "type": "string"
                         },
                         "bucket": {
                             "type": "string"
                         },
                         "credential": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "sentry": {
+                    "type": "object",
+                    "properties": {
+                        "dsn": {
                             "type": "string"
                         }
                     }

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -1,33 +1,11 @@
 ## @section Runner configuration Parameters
 ##
 
-## The list of secrets that need to be created for deploying DeepSource Runner
-##
-secrets:
-  ## The secret that contains the DeepSource Runner configuration. Check the `config` field
-  ## for the format of the config
-  ##
-  runnerSecret:
-    ## @param secrets.runnerSecret.create Set to `false` if the secret has been created manually
-    create: true
-    secretName: "deepsource-runner-config"
-  ## The secret to pull images from registry
-  ##
-  imagePullSecret:
-    ## @param secrets.imagePullSecret.create Set to `false` if the secret has been created manually
-    create: true
-    secretName: "deepsource-runner-image-registry"
-  ## The secret that containing the credentials to upload and download artifacts to/from remote object storage provider
-  ##
-  artifactsSecret:
-    ## @param secrets.artifactsSecret.create Set to `false` if the secret has been created manually
-    create: true
-    secretName: "deepsource-runner-artifacts-credentials"
-
-
 ## The configuration values for deepsource runner, this will create a secret to be used by the runner
 ##
 config:
+  createSecret: true
+  secretName: ""
   ## @param config.apps Configuration values for the VCS apps to be used by the runner
   ## apps:
   ## - id: app1
@@ -53,6 +31,8 @@ config:
   ## Configuration values for the object storage to use for the runner
   ##
   objectStorage:
+    createSecret: true
+    secretName: ""
     ## @param config.objectStorage.provider The provider to use for the object storage (e.g gcs, s3)
     ##
     provider: ""
@@ -120,6 +100,8 @@ image:
 ## @param imageRegistry.username The username to use for the image registry
 ## @param imageRegistry.password The password to use for the image registry
 imageRegistry:
+  createSecret: true
+  secretName: ""
   registryUrl: ""
   username: ""
   password: ""

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -4,7 +4,11 @@
 ## The configuration values for deepsource runner, this will create a secret to be used by the runner
 ##
 config:
+  ## @param config.createSecret Whether to create a secret for the runner config
+  ##
   createSecret: true
+  ## @param config.secretName The name of the secret to use for the runner, if created externally
+  ##
   secretName: ""
   ## @param config.apps Configuration values for the VCS apps to be used by the runner
   ## apps:
@@ -31,7 +35,11 @@ config:
   ## Configuration values for the object storage to use for the runner
   ##
   objectStorage:
+    ## @param config.objectStorage.createSecret Whether to create a secret for the object storage
+    ##
     createSecret: true
+    ## @param config.objectStorage.secretName The name of the secret to use for the object storage, if created externally
+    ##
     secretName: ""
     ## @param config.objectStorage.provider The provider to use for the object storage (e.g gcs, s3)
     ##
@@ -77,6 +85,12 @@ config:
     key: ""
     ## @param config.saml.metadataUrl The metadata url to use for the identity provider
     metadataUrl: ""
+  ## Configuration values for the sentry integration
+  ##
+  sentry:
+    ## @param config.sentry.dsn The DSN to use for the sentry integration
+    ##
+    dsn: ""
 
 ## @section Common Parameters
 ##
@@ -96,6 +110,8 @@ image:
   tag: ""
 
 ## Deepsource runner image registry configuration
+## @param imageRegistry.createSecret Whether to create a secret for the image registry
+## @param imageRegistry.secretName The name of the secret to use for the image registry, if created externally
 ## @param imageRegistry.registryUrl The registry url to use for the task images
 ## @param imageRegistry.username The username to use for the image registry
 ## @param imageRegistry.password The password to use for the image registry

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -1,6 +1,30 @@
 ## @section Runner configuration Parameters
 ##
 
+## The list of secrets that need to be created for deploying DeepSource Runner
+##
+secrets:
+  ## The secret that contains the DeepSource Runner configuration. Check the `config` field
+  ## for the format of the config
+  ##
+  runnerSecret:
+    ## @param secrets.runnerSecret.create Set to `false` if the secret has been created manually
+    create: true
+    secretName: "deepsource-runner-config"
+  ## The secret to pull images from registry
+  ##
+  imagePullSecret:
+    ## @param secrets.imagePullSecret.create Set to `false` if the secret has been created manually
+    create: true
+    secretName: "deepsource-runner-image-registry"
+  ## The secret that containing the credentials to upload and download artifacts to/from remote object storage provider
+  ##
+  artifactsSecret:
+    ## @param secrets.artifactsSecret.create Set to `false` if the secret has been created manually
+    create: true
+    secretName: "deepsource-runner-artifacts-credentials"
+
+
 ## The configuration values for deepsource runner, this will create a secret to be used by the runner
 ##
 config:
@@ -29,9 +53,9 @@ config:
   ## Configuration values for the object storage to use for the runner
   ##
   objectStorage:
-    ## @param config.objectStorage.backend The backend to use for the object storage (e.g gcs)
+    ## @param config.objectStorage.provider The provider to use for the object storage (e.g gcs, s3)
     ##
-    backend: ""
+    provider: ""
     ## @param config.objectStorage.bucket The bucket to use for the object storage
     ##
     bucket: ""


### PR DESCRIPTION
Adds support for allowing users to specify if they want to deploy runner using manually created secrets.
Adds support for adding sentry dsn for exceptions